### PR TITLE
add download job content, fix issue in the back button in admin navbar

### DIFF
--- a/src/app/admin/admin-navbar/admin-navbar.component.ts
+++ b/src/app/admin/admin-navbar/admin-navbar.component.ts
@@ -1,6 +1,8 @@
 import { Component, Input, OnDestroy, OnInit, ViewEncapsulation } from '@angular/core';
 import { DARK_THEME, DarkThemeService } from '@irohalab/deneb-ui';
 import { Subscription } from 'rxjs';
+import { Router } from '@angular/router';
+import { NavigationService } from '../../navigation.service';
 
 @Component({
     selector: 'admin-navbar',
@@ -19,7 +21,9 @@ export class AdminNavbar implements OnInit, OnDestroy {
 
     isDarkTheme: boolean;
 
-    constructor(private _darkThemeService: DarkThemeService) {
+    constructor(private _darkThemeService: DarkThemeService,
+                private _navigationService: NavigationService,
+                private _router: Router) {
     }
 
     ngOnDestroy(): void {
@@ -35,5 +39,9 @@ export class AdminNavbar implements OnInit, OnDestroy {
                     this.isDarkTheme = theme === DARK_THEME;
                 })
         );
+    }
+
+    back(): void {
+        this._navigationService.goBack(this.backLink);
     }
 }

--- a/src/app/admin/admin-navbar/admin-navbar.html
+++ b/src/app/admin/admin-navbar/admin-navbar.html
@@ -1,5 +1,5 @@
 <nav class="nav-admin" [ngClass]="{'dark-theme': isDarkTheme}">
-    <a class="back-button" [routerLink]="backLink" *ngIf="backLink">
+    <a class="back-button" (click)="back()" *ngIf="backLink">
         <i class="chevron left icon"></i>
     </a>
     <div class="title">{{navTitle}}</div>

--- a/src/app/admin/bangumi-detail/video-processs-rule/action-editor/action-editor.html
+++ b/src/app/admin/bangumi-detail/video-processs-rule/action-editor/action-editor.html
@@ -164,6 +164,7 @@
                         <div class="text" *ngIf="$any(actions[selectedActionId]).extractFrom">{{$any(actions[selectedActionId]).extractFrom}}</div>
                         <div class="menu">
                             <div class="item" (click)="updateActionExtractSource(eExtractSource.VideoFile)">{{eExtractSource.VideoFile}}</div>
+                            <div class="item" (click)="updateActionExtractSource(eExtractSource.Archive)">{{eExtractSource.Archive}}</div>
                             <div class="item" (click)="updateActionExtractSource(eExtractSource.OtherFiles)">{{eExtractSource.OtherFiles}}</div>
                         </div>
                     </div>
@@ -191,7 +192,7 @@
                            name="outputExtname"
                            placeholder="extension name of output"/>
                 </div>
-                <div class="field"  *ngIf="$any(actions[selectedActionId]).extractorId === 'Default'">
+                <div class="field" *ngIf="$any(actions[selectedActionId]).extractorId === 'Default'">
                     <label>extractRegex</label>
                     <input type="text"
                            [(ngModel)]="$any(actions[selectedActionId]).extractRegex"
@@ -200,7 +201,7 @@
                            name="extractRegex"
                            placeholder="regex to match file/track"/>
                 </div>
-                <div class="field"  *ngIf="$any(actions[selectedActionId]).extractorId === 'Subtitle' || $any(actions[selectedActionId]).extractorId === 'Audio'">
+                <div class="field" *ngIf="$any(actions[selectedActionId]).extractorId === 'Subtitle' || $any(actions[selectedActionId]).extractorId === 'Audio'">
                     <label>extraData.propertyName</label>
                     <input type="text"
                            [(ngModel)]="$any(actions[selectedActionId]).extraData.propertyName"
@@ -209,7 +210,7 @@
                            name="propertyName"
                            placeholder="property name of the stream info to match"/>
                 </div>
-                <div class="field"  *ngIf="$any(actions[selectedActionId]).extractorId === 'Subtitle' || $any(actions[selectedActionId]).extractorId === 'Audio'">
+                <div class="field" *ngIf="$any(actions[selectedActionId]).extractorId === 'Subtitle' || $any(actions[selectedActionId]).extractorId === 'Audio'">
                     <label>extraData.propertyValueRegex</label>
                     <input type="text"
                            [(ngModel)]="$any(actions[selectedActionId]).extraData.propertyValueRegex"
@@ -218,7 +219,7 @@
                            name="propertyValueRegex"
                            placeholder="regular expression of the property of stream info"/>
                 </div>
-                <div class="field"  *ngIf="$any(actions[selectedActionId]).extractorId === 'Audio'">
+                <div class="field" *ngIf="$any(actions[selectedActionId]).extractorId === 'Audio'">
                     <label>extraData.selectDefault</label>
                     <input type="text"
                            [(ngModel)]="$any(actions[selectedActionId]).extraData.selectDefault"
@@ -227,20 +228,39 @@
                            name="selectDefault"
                            placeholder="if select the default stream"/>
                 </div>
+                <div class="field" *ngIf="$any(actions[selectedActionId]).extractorId === 'File' && $any(actions[selectedActionId]).extractTarget === eExtractTarget.Subtitle">
+                    <label>extraData.fileNameHint (case-insensitive)</label>
+                    <input type="text"
+                           [(ngModel)]="$any(actions[selectedActionId]).extraData.fileNameHint"
+                           (ngModelChange)="updateNode()"
+                           [ngModelOptions]="{updateOn: 'blur'}"
+                           name="fileNameHint"
+                           placeholder="Regex to match filename (optional)">
+                    <small>Use EPS_NO as named capture to capture episode number</small>
+                </div>
+                <div class="field" *ngIf="$any(actions[selectedActionId]).extractorId === 'File' && $any(actions[selectedActionId]).extractFrom === eExtractSource.Archive">
+                    <label>extraData.archiveFileNameHint (case-insensitive)</label>
+                    <input type="text"
+                           [(ngModel)]="$any(actions[selectedActionId]).extraData.archiveFileNameHint"
+                           (ngModelChange)="updateNode()"
+                           [ngModelOptions]="{updateOn: 'blur'}"
+                           name="archiveFileNameHint"
+                           placeholder="Regex to match archive filename">
+                </div>
                 <!-- extractorId is not supported currently -->
                 <button class="ui icon button" (click)="removeSelectedNode()"><i class="trash alternate icon"></i></button>
             </div>
             <!-- for debug only, hide in production -->
-            <div class="ui mini form">
-                <div class="field" *ngFor="let actId of actions[selectedActionId].upstreamActionIds">
-                    <label>Upstream Action Id</label>
-                    <input type="text" [value]="actId" readonly>
-                </div>
-                <div class="field" *ngFor="let actId of actions[selectedActionId].downstreamIds">
-                    <label>Downstream Action Id</label>
-                    <input type="text" [value]="actId" readonly>
-                </div>
-            </div>
+<!--            <div class="ui mini form">-->
+<!--                <div class="field" *ngFor="let actId of actions[selectedActionId].upstreamActionIds">-->
+<!--                    <label>Upstream Action Id</label>-->
+<!--                    <input type="text" [value]="actId" readonly>-->
+<!--                </div>-->
+<!--                <div class="field" *ngFor="let actId of actions[selectedActionId].downstreamIds">-->
+<!--                    <label>Downstream Action Id</label>-->
+<!--                    <input type="text" [value]="actId" readonly>-->
+<!--                </div>-->
+<!--            </div>-->
         </div>
         <div class="link-card ui segment" *ngIf="selectedLinkId && selectedLinkIndex !== -1">
             <span>Link: </span>

--- a/src/app/admin/download-manager/download-job-detail/download-job-detail.html
+++ b/src/app/admin/download-manager/download-job-detail/download-job-detail.html
@@ -85,4 +85,23 @@
             <pre>{{job.errorInfo.stack}}</pre>
         </div>
     </div>
+    <div class="job-content">
+        <div class="section-header">Content</div>
+        <table class="file-list-table ui table">
+            <thead>
+            <tr>
+                <th>Path</th>
+                <th>Size</th>
+                <th>Progress</th>
+            </tr>
+            </thead>
+            <tbody>
+            <tr *ngFor="let torrentFile of jobContent">
+                <td>{{torrentFile.name}}</td>
+                <td>{{torrentFile.size | readableUnit:'byte':1}}</td>
+                <td>{{torrentFile.progress | percent}}</td>
+            </tr>
+            </tbody>
+        </table>
+    </div>
 </div>

--- a/src/app/admin/download-manager/download-job-detail/download-job-detail.less
+++ b/src/app/admin/download-manager/download-job-detail/download-job-detail.less
@@ -12,8 +12,20 @@
   overflow: hidden;
   box-shadow: -5px 0 5px #7c7c7c;
 }
+
+.job-detail-container {
+  padding-top: 2.6rem;
+  overflow-y: scroll;
+  width: 100%;
+  height: 100%;
+}
+
 .header-bar {
   height: 2.5rem;
+  position: absolute;
+  left: 0;
+  top: 0;
+  width: 100%;
   border-bottom: 1px solid #cccccc;
   display: flex;
   flex-direction: row;
@@ -38,7 +50,7 @@
   }
 }
 
-.job-basic-info, .job-summary {
+.job-basic-info, .job-summary, .job-content {
   margin: 0.5rem 1rem;
 }
 

--- a/src/app/admin/download-manager/download-manager.service.ts
+++ b/src/app/admin/download-manager/download-manager.service.ts
@@ -8,6 +8,7 @@ import { catchError, map, switchMap, tap } from 'rxjs/operators';
 import { FileMapping } from '../../entity/FileMapping';
 import { Bangumi } from '../../entity';
 import { AdminService } from '../admin.service';
+import { TorrentFile } from '../../entity/TorrentFile';
 
 type ReqData = {
     method: 'GET' | 'POST' | 'PUT' | 'DELETE';
@@ -108,6 +109,15 @@ export class DownloadManagerService extends BaseService {
         }
         return this.sendRequest<{ status: number }>(reqData)
             .pipe(map(res => res.status), catchError(this.handleError));
+    }
+
+    public getJobContent(jobId: string): Observable<TorrentFile[]> {
+        const reqData: ReqData = {
+            method: 'GET',
+            url: `/download/job/${jobId}/content`
+        };
+        return this.sendRequest<{data: TorrentFile[], status: number}>(reqData)
+            .pipe(map(res => res.data), catchError(this.handleError));
     }
 
     public getBangumi(id: string): Observable<Bangumi> {

--- a/src/app/admin/video-process-job-detail/video-process-job-detail.component.ts
+++ b/src/app/admin/video-process-job-detail/video-process-job-detail.component.ts
@@ -1,7 +1,7 @@
 import { AfterViewInit, Component, ElementRef, OnDestroy, OnInit, ViewChild } from '@angular/core';
 import { VideoProcessManagerService } from '../video-process-manager/video-process-manager.service';
 import { combineLatestWith, delay, interval, Subject, Subscription } from 'rxjs';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { switchMap, takeWhile, tap } from 'rxjs/operators';
 import { UIDialog, UIDialogRef, UIToast, UIToastComponent, UIToastRef } from '@irohalab/deneb-ui';
 import { VideoProcessJob } from '../../entity/VideoProcessJob';
@@ -48,6 +48,7 @@ export class VideoProcessJobDetailComponent implements OnInit, OnDestroy, AfterV
     constructor(private _videoProcessManagerService: VideoProcessManagerService,
                 private _adminService: AdminService,
                 private _route: ActivatedRoute,
+                private _router: Router,
                 private _dialog: UIDialog,
                 toastService: UIToast,
                 private titleService: Title) {

--- a/src/app/admin/video-process-job-detail/video-process-job-detail.html
+++ b/src/app/admin/video-process-job-detail/video-process-job-detail.html
@@ -1,4 +1,4 @@
-<admin-navbar navTitle="Video Process Job" backLink="/admin/video-manager">
+<admin-navbar navTitle="Video Process Job" backLink="/admin/video-manager?status=Running">
     <a class="accessory-action anchor-button"
        title="Cancel"
        *ngIf="job && (job.status === eJobStatus.Running || job.status === eJobStatus.Queueing)"

--- a/src/app/admin/video-process-manager/video-process-manager.component.ts
+++ b/src/app/admin/video-process-manager/video-process-manager.component.ts
@@ -4,9 +4,10 @@ import { VideoProcessJobStatus } from '../../entity/VideoProcessJobStatus';
 import { VideoProcessJob } from '../../entity/VideoProcessJob';
 import { VideoProcessManagerService } from './video-process-manager.service';
 import { getRemPixel } from '../../../helpers/dom';
-import { switchMap } from 'rxjs/operators';
+import { filter, switchMap } from 'rxjs/operators';
 import { Title } from '@angular/platform-browser';
 import { environment } from '../../../environments/environment';
+import { ActivatedRoute } from '@angular/router';
 
 const JOB_CARD_HEIGHT_REM = 4.5;
 
@@ -26,6 +27,7 @@ export class VideoProcessManagerComponent implements OnInit, OnDestroy {
     selectJobStatus: VideoProcessJobStatus = VideoProcessJobStatus.Running;
 
     constructor(private _videoProcessManagerService: VideoProcessManagerService,
+                private _route: ActivatedRoute,
                 titleService: Title) {
         titleService.setTitle(`视频管理 - ${environment.siteTitle}`);
         if (window) {
@@ -39,11 +41,18 @@ export class VideoProcessManagerComponent implements OnInit, OnDestroy {
     }
 
     ngOnInit(): void {
-        this.updateJobList();
-    }
-
-    onChangeStatus(status: VideoProcessJobStatus) {
-        this.selectJobStatus = status;
+        this._sub.add(
+            this._route.queryParams
+                .pipe(
+                    filter((params) => {
+                        return params['status'];
+                    })
+                )
+                .subscribe((params) => {
+                    this.selectJobStatus = params['status'] as VideoProcessJobStatus;
+                    this.updateJobList();
+                })
+        );
         this.updateJobList();
     }
 

--- a/src/app/admin/video-process-manager/video-process-manager.html
+++ b/src/app/admin/video-process-manager/video-process-manager.html
@@ -6,12 +6,12 @@
 </admin-navbar>
 <div class="sub-menu">
     <div class="ui secondary vertical pointing menu">
-        <div class="item" [ngClass]="{active: selectJobStatus === eJobStatus.Queueing}" (click)="onChangeStatus(eJobStatus.Queueing)">Queueing</div>
-        <div class="item" [ngClass]="{active: selectJobStatus === eJobStatus.Running}" (click)="onChangeStatus(eJobStatus.Running)">Running</div>
-        <div class="item" [ngClass]="{active: selectJobStatus === eJobStatus.Finished}" (click)="onChangeStatus(eJobStatus.Finished)">Finished</div>
-        <div class="item" [ngClass]="{active: selectJobStatus === eJobStatus.UnrecoverableError}" (click)="onChangeStatus(eJobStatus.UnrecoverableError)">UnrecoverableError</div>
-        <div class="item" [ngClass]="{active: selectJobStatus === eJobStatus.Pause}" (click)="onChangeStatus(eJobStatus.Pause)">Pause</div>
-        <div class="item" [ngClass]="{active: selectJobStatus === eJobStatus.Canceled}" (click)="onChangeStatus(eJobStatus.Canceled)">Canceled</div>
+        <div class="item" routerLinkActive="active" [routerLink]="['/admin/video-manager']" [queryParams]="{status: eJobStatus.Queueing}">Queueing</div>
+        <div class="item" routerLinkActive="active" [routerLink]="['/admin/video-manager']" [queryParams]="{status: eJobStatus.Running}">Running</div>
+        <div class="item" routerLinkActive="active" [routerLink]="['/admin/video-manager']" [queryParams]="{status: eJobStatus.Finished}">Finished</div>
+        <div class="item" routerLinkActive="active" [routerLink]="['/admin/video-manager']" [queryParams]="{status: eJobStatus.UnrecoverableError}">UnrecoverableError</div>
+        <div class="item" routerLinkActive="active" [routerLink]="['/admin/video-manager']" [queryParams]="{status: eJobStatus.Pause}">Pause</div>
+        <div class="item" routerLinkActive="active" [routerLink]="['/admin/video-manager']" [queryParams]="{status: eJobStatus.Canceled}">Canceled</div>
     </div>
 </div>
 <div class="content-area">

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -6,6 +6,7 @@ import { Component, ViewEncapsulation } from '@angular/core';
 import { AnalyticsService } from './analytics.service';
 import { Router, NavigationEnd, NavigationStart } from '@angular/router';
 import { Subscription } from 'rxjs';
+import { NavigationService } from './navigation.service';
 
 /*
  * App Component
@@ -35,7 +36,7 @@ export class App {
         }
     }
 
-    constructor(analyticsSerivce: AnalyticsService, router: Router) {
+    constructor(analyticsSerivce: AnalyticsService, router: Router, navigationService: NavigationService) {
         this.routeEventsSubscription = router.events
             .subscribe(
                 (event) => {
@@ -43,7 +44,9 @@ export class App {
                         this.removePreLoader();
                     }
                 }
-            )
+            );
+
+        navigationService.startSaveHistory();
     }
 }
 

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { ResetPassModule } from './reset-pass/reset-pass.module';
 import { UserServiceModule } from './user-service/index';
 import { StaticContentModule } from './static-content/static-content.module';
 import { RefreshSameRouteStrategy } from './RefreshSameRouteStrategy';
+import { NavigationService } from './navigation.service';
 
 @NgModule({
     declarations: [
@@ -27,6 +28,7 @@ import { RefreshSameRouteStrategy } from './RefreshSameRouteStrategy';
     ],
     providers: [
         AnalyticsService,
+        NavigationService,
         TaskService,
         {
             provide: RouteReuseStrategy,

--- a/src/app/entity/ExtractAction.ts
+++ b/src/app/entity/ExtractAction.ts
@@ -17,6 +17,6 @@ export class ExtractAction extends Action {
     // be by default .vtt, this may cause an issue.
     public outputExtname: string;
     public extractRegex: string;
-    public extractorId = 'Default';
+    public extractorId = 'File';
     public extraData: any = {};
 }

--- a/src/app/entity/ExtractSource.ts
+++ b/src/app/entity/ExtractSource.ts
@@ -1,4 +1,5 @@
 export enum ExtractSource {
     VideoFile = 'VideoFile',
+    Archive = 'Archive',
     OtherFiles = 'OtherFiles'
 }

--- a/src/app/entity/TorrentFile.ts
+++ b/src/app/entity/TorrentFile.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+export class TorrentFile {
+    public index: string;
+    public name: string; // must be relative path (relative to save path)
+    public size: number;
+    public progress: number;
+}

--- a/src/app/navigation.service.ts
+++ b/src/app/navigation.service.ts
@@ -1,0 +1,29 @@
+import { Injectable } from '@angular/core';
+import { Location } from '@angular/common';
+import { NavigationEnd, Router } from '@angular/router';
+
+@Injectable({providedIn: 'root'})
+export class NavigationService {
+    private _history: string[] = [];
+
+    constructor(private _router: Router, private _location: Location) {
+    }
+
+    public startSaveHistory(): void {
+        this._router.events.subscribe((event) => {
+            if (event instanceof NavigationEnd) {
+                this._history.push(event.urlAfterRedirects);
+            }
+        });
+    }
+
+    public goBack(fallBackUrl: string = '/'): void {
+        this._history.pop();
+
+        if (this._history.length > 0) {
+            this._location.back();
+        } else {
+            this._router.navigateByUrl(fallBackUrl);
+        }
+    }
+}


### PR DESCRIPTION
- Add torrent content in the Download Job Detail panel
- fix clicking the back button only returns to the parent route, not back to the previous route.
- Replace `Default` with `File` for the default extractorId
- For the VideoProcess manager, the side navigate now uses route to switch between different status