### PR TITLE
Add List Layout for episodes list

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mira-ui",
-  "version": "2.8.2",
+  "version": "2.9.0",
   "scripts": {
     "ng": "ng",
     "start": "ng serve",

--- a/src/app/home/bangumi-detail/bangumi-detail.dark.less
+++ b/src/app/home/bangumi-detail/bangumi-detail.dark.less
@@ -33,7 +33,16 @@
 .dark-episode-list() {
   .episode-list {
     background-color: transparent;
-    .episode-card {
+    .episode-layout-button-groups {
+      > .layout-button {
+        color: @darkLinkColor;
+        &:focus,
+        &:hover {
+          color: @darkLinkHoverColor;
+        }
+      }
+    }
+    .episode-card, .episode-list-view-item {
       background-color: lighten(@darkBackground, 5%);
       box-shadow: 0px 1px 3px 0px @darkBoxShadowColor, 0px 0px 0px 1px @darkBoxShadowColor;
       .image-fallback {
@@ -49,6 +58,9 @@
       }
       .content.unfinished {
         color: darken(@darkLinkColor, 10%);
+        .content-heading {
+          color: darken(@darkLinkColor, 10%);
+        }
       }
     }
   }

--- a/src/app/home/bangumi-detail/bangumi-detail.html
+++ b/src/app/home/bangumi-detail/bangumi-detail.html
@@ -47,9 +47,73 @@
     </div>
     <div class="episode-list">
         <h4 class="episode-list-heading">各话列表</h4>
+        <div class="episode-layout-button-groups">
+            <a class="layout-button sort-button" [title]="sortOrder === 'desc' ? '最早在前，显示所有' : '最新在前，仅显示可观看'" (click)="toggleSortOrder()">
+                <i class="ui sort numeric icon" [ngClass]="{up: sortOrder === 'asc', down: sortOrder === 'desc'}"></i>
+            </a>
+            <a class="layout-button" title="网格视图" (click)="changeLayoutType(eLayoutTypes.GRID)"><i class="ui th icon"></i></a>
+            <a class="layout-button" title="列表视图" (click)="changeLayoutType(eLayoutTypes.LIST)"><i class="ui th list icon"></i></a>
+        </div>
         <div class="ui divider"></div>
-        <div class="ui six doubling cards">
-            <div class="card episode-card" *ngFor="let episode of bangumi.episodes">
+        <div *ngIf="layoutType === eLayoutTypes.LIST" class="episode-list-view ui stackable two column grid">
+            <div class="column" *ngFor="let episode of episodeList">
+                <div class="ui segment episode-list-view-item">
+                    <div class="image" *ngIf="episode.status!==2">
+                        <div class="image-wrapper">
+                            <div class="image-fallback">
+                                <h4 class="ui icon film icon-holder">
+                                    <i class="film icon"></i>
+                                </h4>
+                            </div>
+                        </div>
+                    </div>
+                    <div *ngIf="episode.status!==2" class="content unfinished">
+                        <div class="content-heading">
+                            <span>第{{episode.episode_no}}话&nbsp;</span>
+                            <span *ngIf="episode.name_cn || episode.name">{{episode.name_cn || episode.name}}</span>
+                        </div>
+                        <div class="extra-info">
+                            <span>时长:&nbsp;{{episode.duration}}</span>
+                            <span>更新时间:{{episode.airdate}}</span>
+                            <span class="ui tiny teal label" *ngIf="sortOrder === 'desc' && episode.status !== 2">即将播出</span>
+                        </div>
+                    </div>
+                    <a *ngIf="episode.status===2" class="image" [routerLink]="['/play', episode.id]">
+                        <responsive-image [src]="episode.thumbnail_image.url"
+                                          [size]="{
+                                        width: '100%',
+                                        ratio: 0.5625,
+                                        originalWidth: episode.thumbnail_image.width,
+                                        originalHeight: episode.thumbnail_image.height}"
+                                          [background]="episode.thumbnail_image.dominant_color"></responsive-image>
+                    </a>
+                    <a *ngIf="episode.status===2" class="content" [routerLink]="['/play', episode.id]">
+                        <div class="content-heading">
+                            <span>第{{episode.episode_no}}话</span>
+                            <span *ngIf="episode.name_cn || episode.name">{{episode.name_cn || episode.name}}</span>
+                        </div>
+                        <div class="extra-info">
+                            <span>时长:&nbsp;{{episode.duration}}</span>
+                            <span>更新时间:{{episode.airdate}}</span>
+                            <span class="ui tiny teal label" *ngIf="sortOrder === 'desc' && episode.status !== 2">即将播出</span>
+                        </div>
+                    </a>
+                    <div class="ui bottom attached progress"
+                         *ngIf="episode.watch_progress && episode.watch_progress.percentage"
+                         [ngClass]="{
+                     orange: episode.watch_progress.watch_status === 1,
+                     olive: episode.watch_progress.watch_status === 2,
+                     blue: episode.watch_progress.watch_status === 3,
+                     brown: episode.watch_progress.watch_status === 4,
+                     grey: episode.watch_progress.watch_status === 5
+                     }">
+                        <div class="bar" [style.width]="episode.watch_progress.percentage * 100 + '%'"></div>
+                    </div>
+                </div>
+            </div>
+        </div>
+        <div *ngIf="layoutType === eLayoutTypes.GRID" class="ui six doubling cards">
+            <div class="card episode-card" *ngFor="let episode of episodeList">
                 <div class="image" *ngIf="episode.status!==2">
                     <div class="image-wrapper">
                         <div class="image-fallback">
@@ -60,7 +124,7 @@
                     </div>
                 </div>
                 <div *ngIf="episode.status!==2" class="content unfinished">
-                    <span>第{{episode.episode_no}}话</span>
+                    <span class="episode-title" *ngIf="episode.name_cn || episode.name">{{episode.name_cn || episode.name}}</span>
                 </div>
                 <a *ngIf="episode.status===2" class="image" [routerLink]="['/play', episode.id]">
                     <responsive-image [src]="episode.thumbnail_image.url"
@@ -71,8 +135,9 @@
                                         originalHeight: episode.thumbnail_image.height}"
                                       [background]="episode.thumbnail_image.dominant_color"></responsive-image>
                 </a>
+                <span class="episode-number">{{episode.episode_no}}</span>
                 <a *ngIf="episode.status===2" class="content" [routerLink]="['/play', episode.id]">
-                    <span>第{{episode.episode_no}}话</span>
+                    <span class="episode-title" *ngIf="episode.name_cn || episode.name">{{episode.name_cn || episode.name}}</span>
                 </a>
                 <div class="ui bottom attached progress"
                      *ngIf="episode.watch_progress && episode.watch_progress.percentage"

--- a/src/app/home/bangumi-detail/bangumi-detail.less
+++ b/src/app/home/bangumi-detail/bangumi-detail.less
@@ -164,9 +164,27 @@
     margin: 0;
     padding: 2rem 0 0 0;
   }
+
+  .episode-layout-button-groups {
+    position: absolute;
+    right: 0.4rem;
+    top: 2.2rem;
+    > .sort-button {
+      margin-right: 1.5em;
+    }
+    > .layout-button {
+      display: inline-block;
+      cursor: pointer;
+      color: #4c4c4c;
+      &:focus,
+      &:hover {
+        color: #101010;
+      }
+    }
+  }
 }
 
-.episode-card {
+.episode-card, .episode-list-view {
   overflow: hidden;
   .image-wrapper {
     display: block;
@@ -208,6 +226,53 @@
   .ui.bottom.attached.progress {
     .bar {
       min-width: 1rem;
+    }
+  }
+  .episode-number {
+    position: absolute;
+    left: 0;
+    top: 0;
+    color: #ffffff;
+    background-color: rgba(0, 0, 0, 0.5);
+    padding: 0.1em 0.4em;
+    border-radius: 0 0 0.28571429rem 0 !important;
+  }
+}
+
+.episode-list-view {
+  @media only screen and (max-width: 767px) {
+    &.ui.stackable.grid {
+      margin-left: -1rem !important;
+      margin-right: -1rem !important;
+    }
+  }
+  .episode-list-view-item {
+    display: flex;
+    flex-direction: row;
+    justify-content: flex-start;
+    padding: 0;
+    > .image {
+      width: 8rem;
+      flex: 0 0 8rem;
+    }
+    > .content {
+      padding: 0.7em 1em;
+      .extra-info {
+        margin-top: 0.2em;
+        font-size: 0.8rem;
+        color: #a9a9a9;
+        > span {
+          display: inline-block;
+        }
+        > span:not(:last-child) {
+          margin-right: 1.5em;
+        }
+      }
+    }
+    > .content.unfinished {
+      .content-heading {
+        color: #696969;
+      }
     }
   }
 }

--- a/src/app/home/play-episode/play-episode.dark.less
+++ b/src/app/home/play-episode/play-episode.dark.less
@@ -7,7 +7,16 @@
         color: darken(@darkForeground, 25%);
       }
     }
-    .episode-list {
+    .episode-layout-button-groups {
+      > .layout-button {
+        color: @darkLinkColor;
+        &:focus,
+        &:hover {
+          color: @darkLinkHoverColor;
+        }
+      }
+    }
+    .episode-list-view, .episode-grid-view {
       .episode-link.ui.segment {
         background: @darkPanelBg;
         color: @darkLinkColor;

--- a/src/app/home/play-episode/play-episode.html
+++ b/src/app/home/play-episode/play-episode.html
@@ -60,20 +60,42 @@
                 {{episode.bangumi.summary}}
             </div>
             <reveal-extra [bangumi]="episode.bangumi"></reveal-extra>
-            <h4>
-                各话列表
-            </h4>
-            <div class="episode-list-loading-wrapper" *ngIf="!episode.bangumi.episodes">
-                <div class="ui active medium loader"></div>
-            </div>
-            <div class="episode-list ui eight column doubling grid" *ngIf="episode.bangumi.episodes" [ngClass]="{inverted: isDarkTheme}">
-                <div class="column" *ngFor="let eps of episode.bangumi.episodes">
-                    <a class="ui segment episode-link" *ngIf="eps.status===2" [routerLink]="['/play', eps.id]" [ngClass]="{'dark-panel': isDarkTheme}">
-                        {{eps.episode_no}}
+            <div class="episode-list-container">
+                <h4>
+                    各话列表
+                </h4>
+                <div class="episode-layout-button-groups">
+                    <a class="layout-button sort-button" [title]="sortOrder === 'desc' ? '最早在前，显示所有' : '最新在前，仅显示可观看'" (click)="toggleSortOrder()">
+                        <i class="ui sort numeric icon" [ngClass]="{up: sortOrder === 'asc', down: sortOrder === 'desc'}"></i>
                     </a>
-                    <a class="ui disabled segment episode-link" *ngIf="eps.status!==2" [ngClass]="{inverted: isDarkTheme}">
-                        {{eps.episode_no}}
-                    </a>
+                    <a class="layout-button" title="网格视图" (click)="changeLayoutType(eLayoutTypes.GRID)"><i class="ui th icon"></i></a>
+                    <a class="layout-button" title="列表视图" (click)="changeLayoutType(eLayoutTypes.LIST)"><i class="ui th list icon"></i></a>
+                </div>
+                <div class="ui divider"></div>
+                <div class="episode-list-loading-wrapper" *ngIf="!episode.bangumi.episodes">
+                    <div class="ui active medium loader"></div>
+                </div>
+                <div class="episode-list-view ui stackable two column grid" *ngIf="episode.bangumi.episodes && layoutType === eLayoutTypes.LIST" [ngClass]="{inverted: isDarkTheme}">
+                    <div class="column" *ngFor="let eps of episodeList">
+                        <a class="ui segment episode-link" [title]="eps.name_cn || eps.name || ''" *ngIf="eps.status===2" [routerLink]="['/play', eps.id]" [ngClass]="{'dark-panel': isDarkTheme}">
+                            <span class="eps-no">第{{eps.episode_no}}话</span>
+                            <span class="eps-title">{{eps.name_cn || eps.name || ''}}</span>
+                        </a>
+                        <a class="ui disabled segment episode-link" [title]="eps.name_cn || eps.name || ''" *ngIf="eps.status!==2" [ngClass]="{inverted: isDarkTheme}">
+                            <span class="eps-no">第{{eps.episode_no}}话</span>
+                            <span class="eps-title">{{eps.name_cn || eps.name || ''}}</span>
+                        </a>
+                    </div>
+                </div>
+                <div class="episode-grid-view ui eight column doubling grid" *ngIf="episode.bangumi.episodes && layoutType === eLayoutTypes.GRID" [ngClass]="{inverted: isDarkTheme}">
+                    <div class="column" *ngFor="let eps of episodeList">
+                        <a class="ui segment episode-link" *ngIf="eps.status===2" [routerLink]="['/play', eps.id]" [ngClass]="{'dark-panel': isDarkTheme}">
+                            {{eps.episode_no}}
+                        </a>
+                        <a class="ui disabled segment episode-link" *ngIf="eps.status!==2" [ngClass]="{inverted: isDarkTheme}">
+                            {{eps.episode_no}}
+                        </a>
+                    </div>
                 </div>
             </div>
         </div>

--- a/src/app/home/play-episode/play-episode.less
+++ b/src/app/home/play-episode/play-episode.less
@@ -149,11 +149,29 @@
       }
     }
   }
-
-  .episode-list {
+  .episode-list-view, .episode-grid-view {
     .episode-link {
       display: block;
+    }
+  }
+
+  .episode-grid-view {
+    .episode-link {
       text-align: center;
+    }
+  }
+
+  .episode-list-view {
+    .episode-link {
+      overflow: hidden;
+      white-space: nowrap;
+      text-overflow: ellipsis;
+      .eps-no {
+        display: inline-block;
+        margin-right: 2em;
+        color: #a6a6a6;
+        font-weight: 600;
+      }
     }
   }
 
@@ -166,4 +184,25 @@
 
 .comment-section {
   margin-top: 2rem;
+}
+
+.episode-list-container {
+  position: relative;
+  .episode-layout-button-groups {
+    position: absolute;
+    right: 0.4rem;
+    top: 0;
+    > .sort-button {
+      margin-right: 1.5em;
+    }
+    > .layout-button {
+      display: inline-block;
+      cursor: pointer;
+      color: #4c4c4c;
+      &:focus,
+      &:hover {
+        color: #101010;
+      }
+    }
+  }
 }


### PR DESCRIPTION
- Add a new layout for the episode list in the bangumi detail page and play episode page.
- Add a group of buttons to switch between grid and list layout.
- Add a button to switch the sort order of episodes list. for descent order, hide unavailable episodes except the first one.
