### PR TITLE
remove the requirement of email.

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -83,7 +83,7 @@
             "development": {
               "proxyConfig": "./proxy.conf.json",
               "host": "0.0.0.0",
-              "port": 3000,
+              "port": 4200,
               "buildTarget": "mira-ui:build:development"
             }
           },

--- a/src/app/home/home.component.ts
+++ b/src/app/home/home.component.ts
@@ -129,22 +129,13 @@ export class Home implements OnInit, OnDestroy {
             .subscribe(
                 (user: User) => {
                     this.user = user;
-                    if (user && (!user.email_confirmed || !user.email)) {
+                    if (user && (!user.email_confirmed)) {
                         console.log('please input your email');
                         let dialogRef = this._dialogService.open(AlertDialog, {stickyDialog: true, backdrop: true});
-                        if (user.email && !user.email_confirmed) {
-                            dialogRef.componentInstance.title = '请验证你的邮箱地址！';
-                            dialogRef.componentInstance.content = '我们已经向您的邮箱地址发送了验证邮件，请前往您的邮箱查看该邮件并完成验证。';
-                            dialogRef.componentInstance.confirmButtonText = '知道了';
-                            this._subscription.add(dialogRef.afterClosed().subscribe(() => {}));
-                        } else {
-                            dialogRef.componentInstance.title = '请填写您的邮箱地址！';
-                            dialogRef.componentInstance.content = '我们检测到您还没有填写邮箱地址，使用邀请码重置密码功能已经关闭。请务必填写邮箱地址以保证正常使用';
-                            dialogRef.componentInstance.confirmButtonText = '前往用户设置';
-                            this._subscription.add(dialogRef.afterClosed().subscribe(() => {
-                                this._router.navigate(['/settings/user']);
-                            }));
-                        }
+                        dialogRef.componentInstance.title = '请验证你的邮箱地址！';
+                        dialogRef.componentInstance.content = '我们已经向您的邮箱地址发送了验证邮件，请前往您的邮箱查看该邮件并完成验证。';
+                        dialogRef.componentInstance.confirmButtonText = '知道了';
+                        this._subscription.add(dialogRef.afterClosed().subscribe(() => {}));
                     }
                 }
             ));

--- a/src/app/home/user-center/user-center.html
+++ b/src/app/home/user-center/user-center.html
@@ -26,8 +26,8 @@
                        formControlName="email"
                        autocomplete="off"
                        (blur)="onFormChanged(emailFormErrors, emailValidationMessages, emailForm)">
-                <span class="warning text" *ngIf="user && user.email && !user.email_confirmed">邮箱地址未验证</span>
-                <button *ngIf="user && user.email && !user.email_confirmed"
+                <span class="warning text" *ngIf="user && !user.email_confirmed">邮箱地址未验证</span>
+                <button *ngIf="user && !user.email_confirmed"
                         type="button"
                         class="ui button"
                         [ngClass]="{inverted: isDarkTheme}"
@@ -53,7 +53,7 @@
                     <!--<li *ngFor="let error of emailFormErrors.current_pass">{{error}}</li>-->
                 <!--</ul>-->
             <!--</div>-->
-            <button type="button" class="ui button" [ngClass]="{inverted: isDarkTheme}" [disabled]="emailForm.invalid || emailForm.pristine" (click)="updateEmail()">保存更改</button>
+            <button type="button" class="ui button" [ngClass]="{inverted: isDarkTheme}" [disabled]="emailForm.invalid || !emailForm.dirty" (click)="updateEmail()">保存更改</button>
         </form>
     </div>
     <div class="ui segment" [ngClass]="{inverted: isDarkTheme}">
@@ -95,7 +95,7 @@
             <div class="ui error message" *ngIf="passwordForm.errors && passwordForm.errors['mismatchedPasswords']">
                 <p>密码不一致</p>
             </div>
-            <button type="button" class="ui button" [ngClass]="{inverted: isDarkTheme}" [disabled]="passwordForm.invalid || passwordForm.pristine" (click)="updatePass()">保存更改</button>
+            <button type="button" class="ui button" [ngClass]="{inverted: isDarkTheme}" [disabled]="passwordForm.invalid || !passwordForm.dirty" (click)="updatePass()">保存更改</button>
         </form>
     </div>
     <div class="ui segment" [ngClass]="{inverted: isDarkTheme}">


### PR DESCRIPTION
The email requirement check is trying to solve a historical issue that, in the very early versions, the site only required users to register with a name and a password, so some users didn't have an email. The UI will prompt the user to add an email address. 

But now most active users should have an email, so we no longer allow users who do not have an email to migrate to V3, so we remove the requirement for email.